### PR TITLE
Sky script is no longer active by default

### DIFF
--- a/src/config.def.js
+++ b/src/config.def.js
@@ -7,7 +7,7 @@ module.exports = {
   startInFullscreen : true,
   scriptSettings : {
     skyColor : {
-      enabled : true,
+      enabled : false,
       color : "#000000",
     },
     autoFFA : {


### PR DESCRIPTION
Why: Because the krunker devs decided that anything messing with the game shouldnt load , like aimbot scrips. and............ sky script......?